### PR TITLE
Feature/job cancel restart status

### DIFF
--- a/api/data/jobs.go
+++ b/api/data/jobs.go
@@ -11,6 +11,8 @@ type Jobs interface {
 	GetJobs(offset, count int) *[]types.Job
 	GetJobByID(id int) (*types.Job, error)
 	GetJobByGUID(id string) (*types.Job, error)
+	GetJobStatusByID(id int) (string, error)
+	GetJobStatusByGUID(guid string) (string, error)
 	GetJobsCount() int
 	GetJobsStats() (*[]Stats, error)
 	CreateJob(job types.Job) *types.Job
@@ -18,7 +20,8 @@ type Jobs interface {
 	UpdateEncodeDataByID(id int64, jsonString string) error
 	UpdateEncodeProgressByID(id int64, progress float64) error
 	UpdateJobByID(id int, job types.Job) *types.Job
-	UpdateJobStatus(guid string, status string) error
+	UpdateJobStatusByID(id int, status string) error
+	UpdateJobStatusByGUID(guid string, status string) error
 }
 
 // JobsOp represents a job operation.
@@ -95,6 +98,42 @@ func (j JobsOp) GetJobByGUID(id string) (*types.Job, error) {
 	}
 	db.Close()
 	return &job, nil
+}
+
+// GetJobStatusByID Gets a job status by GUID.
+func (j JobsOp) GetJobStatusByID(id int) (string, error) {
+	var status string
+	const query = `
+      SELECT
+        status
+      FROM jobs
+      WHERE id = $1`
+
+	db, _ := ConnectDB()
+	err := db.Get(&status, query, id)
+	if err != nil {
+		fmt.Println(err)
+	}
+	db.Close()
+	return status, nil
+}
+
+// GetJobStatusByGUID Gets a job status by GUID.
+func (j JobsOp) GetJobStatusByGUID(guid string) (string, error) {
+	var status string
+	const query = `
+      SELECT
+        status
+      FROM jobs
+      WHERE jobs.guid = $1`
+
+	db, _ := ConnectDB()
+	err := db.Get(&status, query, guid)
+	if err != nil {
+		fmt.Println(err)
+	}
+	db.Close()
+	return status, nil
 }
 
 // GetJobsCount Gets a count of all jobs.
@@ -255,8 +294,25 @@ func (j JobsOp) UpdateJobByID(id int, job types.Job) *types.Job {
 	return &job
 }
 
-// UpdateJobStatus Update job status by ID.
-func (j JobsOp) UpdateJobStatus(guid string, status string) error {
+// UpdateJobStatusByID Update job by ID.
+func (j JobsOp) UpdateJobStatusByID(id int, status string) error {
+	const query = `UPDATE jobs SET status = $1 WHERE id = $2`
+
+	db, _ := ConnectDB()
+	tx := db.MustBegin()
+	_, err := tx.Exec(query, status, id)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	tx.Commit()
+
+	db.Close()
+	return nil
+}
+
+// UpdateJobStatusByGUID Update job status by GUID.
+func (j JobsOp) UpdateJobStatusByGUID(guid string, status string) error {
 	const query = `UPDATE jobs SET status = $1 WHERE guid = $2`
 
 	db, _ := ConnectDB()

--- a/api/data/jobs.go
+++ b/api/data/jobs.go
@@ -9,9 +9,9 @@ import (
 // Jobs represents the Jobs database operations.
 type Jobs interface {
 	GetJobs(offset, count int) *[]types.Job
-	GetJobByID(id int) (*types.Job, error)
+	GetJobByID(id int64) (*types.Job, error)
 	GetJobByGUID(id string) (*types.Job, error)
-	GetJobStatusByID(id int) (string, error)
+	GetJobStatusByID(id int64) (string, error)
 	GetJobStatusByGUID(guid string) (string, error)
 	GetJobsCount() int
 	GetJobsStats() (*[]Stats, error)
@@ -55,7 +55,7 @@ func (j JobsOp) GetJobs(offset, count int) *[]types.Job {
 }
 
 // GetJobByID Gets a job by ID.
-func (j JobsOp) GetJobByID(id int) (*types.Job, error) {
+func (j JobsOp) GetJobByID(id int64) (*types.Job, error) {
 	const query = `
       SELECT
         jobs.*,
@@ -101,7 +101,7 @@ func (j JobsOp) GetJobByGUID(id string) (*types.Job, error) {
 }
 
 // GetJobStatusByID Gets a job status by GUID.
-func (j JobsOp) GetJobStatusByID(id int) (string, error) {
+func (j JobsOp) GetJobStatusByID(id int64) (string, error) {
 	var status string
 	const query = `
       SELECT

--- a/api/encoder/ffmpeg.go
+++ b/api/encoder/ffmpeg.go
@@ -40,7 +40,37 @@ type progress struct {
 
 // ffmpegOptions struct passed into Ffmpeg.Run.
 type ffmpegOptions struct {
-	Options []string `json:"options"`
+	OptionsRaw []string `json:"options_raw"` // Flag options.
+
+	// FFmpeg commander options.
+	Video videoOptions
+	Audio audioOptions
+}
+
+type videoOptions struct {
+	Input                string
+	Output               string
+	Container            string
+	VideoCodec           string
+	VideoSpeed           string
+	AudioCodec           string
+	HardwareAcceleration string
+	Pass                 string
+	Crf                  int
+	Bitrate              string
+	MinRate              string
+	MaxRate              string
+	BufSize              string
+	PixelFormat          string
+	FrameRate            string
+	Speed                string
+	Tune                 string
+	Profile              string
+	Level                string
+}
+
+type audioOptions struct {
+	AudioCodec string
 }
 
 // Run runs the ffmpeg encoder with options.
@@ -53,13 +83,13 @@ func (f *FFmpeg) Run(input string, output string, data string) error {
 	}
 
 	// Decode JSON get options list from data.
-	dat := &ffmpegOptions{}
-	if err := json.Unmarshal([]byte(data), &dat); err != nil {
+	options := &ffmpegOptions{}
+	if err := json.Unmarshal([]byte(data), &options); err != nil {
 		panic(err)
 	}
 
 	// Add the list of options from ffmpeg presets.
-	for _, v := range dat.Options {
+	for _, v := range options.OptionsRaw {
 		args = append(args, strings.Split(v, " ")...)
 	}
 	args = append(args, output)

--- a/api/encoder/ffmpeg.go
+++ b/api/encoder/ffmpeg.go
@@ -45,6 +45,8 @@ type ffmpegOptions struct {
 	OptionsRaw []string `json:"options_raw"` // Flag options.
 
 	// FFmpeg commander options.
+	// TODO: FFmpeg.Run shouold parse and run with struct options.
+	// Currently only supports raw options.
 	Video videoOptions
 	Audio audioOptions
 }

--- a/api/server/jobs.go
+++ b/api/server/jobs.go
@@ -69,6 +69,7 @@ func createJobHandler(c *gin.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	db := data.New()
 	created := db.Jobs.CreateJob(job)
 
@@ -180,4 +181,41 @@ func updateJobByIDHandler(c *gin.Context) {
 
 	updatedJob := db.Jobs.UpdateJobByID(id, *job)
 	c.JSON(http.StatusOK, updatedJob)
+}
+
+func getJobStatusByIDHandler(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+
+	// Update status.
+	db := data.New()
+	status, _ := db.Jobs.GetJobStatusByID(id)
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":     http.StatusOK,
+		"job_status": status,
+	})
+}
+
+func cancelJobByIDHandler(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+
+	// Update status.
+	db := data.New()
+	db.Jobs.UpdateJobStatusByID(id, types.JobCancelled)
+
+	c.JSON(http.StatusOK, gin.H{
+		"status": http.StatusOK,
+	})
+}
+
+func restartJobByIDHandler(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+
+	// Update status.
+	db := data.New()
+	db.Jobs.UpdateJobStatusByID(id, types.JobRestarting)
+
+	c.JSON(http.StatusOK, gin.H{
+		"status": http.StatusOK,
+	})
 }

--- a/api/server/jobs.go
+++ b/api/server/jobs.go
@@ -140,7 +140,7 @@ func getJobsByIDHandler(c *gin.Context) {
 	jobInt, _ := strconv.Atoi(id)
 
 	db := data.New()
-	job, err := db.Jobs.GetJobByID(jobInt)
+	job, err := db.Jobs.GetJobByID(int64(jobInt))
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"status":  http.StatusNotFound,
@@ -166,7 +166,7 @@ func updateJobByIDHandler(c *gin.Context) {
 	}
 
 	db := data.New()
-	job, err := db.Jobs.GetJobByID(id)
+	job, err := db.Jobs.GetJobByID(int64(id))
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"status":  http.StatusNotFound,
@@ -188,7 +188,7 @@ func getJobStatusByIDHandler(c *gin.Context) {
 
 	// Update status.
 	db := data.New()
-	status, _ := db.Jobs.GetJobStatusByID(id)
+	status, _ := db.Jobs.GetJobStatusByID(int64(id))
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":     http.StatusOK,

--- a/api/server/routes.go
+++ b/api/server/routes.go
@@ -26,6 +26,9 @@ func registerRoutes(r *gin.Engine) {
 		api.GET("/jobs", getJobsHandler)
 		api.GET("/jobs/:id", getJobsByIDHandler)
 		api.PUT("/jobs/:id", updateJobByIDHandler)
+		api.GET("/jobs/:id/status", getJobStatusByIDHandler)
+		api.POST("/jobs/:id/cancel", cancelJobByIDHandler)
+		api.POST("/jobs/:id/restart", restartJobByIDHandler)
 
 		// Stats.
 		api.GET("/stats", getStatsHandler)

--- a/api/types/job.go
+++ b/api/types/job.go
@@ -14,6 +14,8 @@ const (
 	JobUploading   = "uploading"
 	JobCompleted   = "completed"
 	JobError       = "error"
+	JobCancelled   = "cancelled"
+	JobRestarting  = "restarting"
 )
 
 // JobStatuses All job status types.
@@ -25,6 +27,8 @@ var JobStatuses = []string{
 	JobUploading,
 	JobCompleted,
 	JobError,
+	JobCancelled,
+	JobRestarting,
 }
 
 // Job describes the job info.

--- a/api/worker/encode_worker.go
+++ b/api/worker/encode_worker.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 
 	"github.com/alfg/openencoder/api/config"
+	"github.com/alfg/openencoder/api/data"
 	"github.com/alfg/openencoder/api/types"
 	"github.com/gocraft/work"
 	"github.com/gomodule/redigo/redis"
@@ -78,6 +79,13 @@ func (c *Context) SendJob(job *work.Job) error {
 				Valid:  true,
 			},
 		},
+	}
+
+	// Check if job is cancelled.
+	db := data.New()
+	jobStatus, _ := db.Jobs.GetJobStatusByGUID(guid)
+	if jobStatus == types.JobCancelled {
+		return nil
 	}
 
 	// Start job.

--- a/api/worker/job.go
+++ b/api/worker/job.go
@@ -197,6 +197,9 @@ func runEncodeJob(job types.Job) {
 	err = encode(job, probeData)
 	if err != nil {
 		log.Error(err)
+		if err := cleanup(job); err != nil {
+			log.Error("cleanup err", err)
+		}
 
 		// Set job to 'cancelled' if it was cancelled.
 		if err.Error() == types.JobCancelled {

--- a/api/worker/job.go
+++ b/api/worker/job.go
@@ -29,7 +29,7 @@ func download(job types.Job) error {
 
 	// Update status.
 	db := data.New()
-	db.Jobs.UpdateJobStatus(job.GUID, types.JobDownloading)
+	db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobDownloading)
 
 	// Get job data.
 	j, _ := db.Jobs.GetJobByGUID(job.GUID)
@@ -58,7 +58,7 @@ func probe(job types.Job) (*encoder.FFProbeResponse, error) {
 
 	// Update status.
 	db := data.New()
-	db.Jobs.UpdateJobStatus(job.GUID, types.JobProbing)
+	db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobProbing)
 
 	// Run FFProbe.
 	f := encoder.FFProbe{}
@@ -80,7 +80,7 @@ func encode(job types.Job, probeData *encoder.FFProbeResponse) error {
 
 	// Update status.
 	db := data.New()
-	db.Jobs.UpdateJobStatus(job.GUID, types.JobEncoding)
+	db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobEncoding)
 
 	p, err := db.Presets.GetPresetByName(job.Preset)
 	if err != nil {
@@ -112,7 +112,7 @@ func upload(job types.Job) error {
 
 	// Update status.
 	db := data.New()
-	db.Jobs.UpdateJobStatus(job.GUID, types.JobUploading)
+	db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobUploading)
 
 	// Get job data.
 	j, _ := db.Jobs.GetJobByGUID(job.GUID)
@@ -151,7 +151,7 @@ func completed(job types.Job) error {
 
 	// Update status.
 	db := data.New()
-	db.Jobs.UpdateJobStatus(job.GUID, types.JobCompleted)
+	db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobCompleted)
 	return nil
 }
 
@@ -185,7 +185,7 @@ func runEncodeJob(job types.Job) {
 	err := download(job)
 	if err != nil {
 		log.Error(err)
-		db.Jobs.UpdateJobStatus(job.GUID, types.JobError)
+		db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobError)
 		return
 	}
 
@@ -193,7 +193,7 @@ func runEncodeJob(job types.Job) {
 	probeData, err := probe(job)
 	if err != nil {
 		log.Error(err)
-		db.Jobs.UpdateJobStatus(job.GUID, types.JobError)
+		db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobError)
 		return
 	}
 
@@ -201,7 +201,7 @@ func runEncodeJob(job types.Job) {
 	err = encode(job, probeData)
 	if err != nil {
 		log.Error(err)
-		db.Jobs.UpdateJobStatus(job.GUID, types.JobError)
+		db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobError)
 		return
 	}
 
@@ -209,7 +209,7 @@ func runEncodeJob(job types.Job) {
 	err = upload(job)
 	if err != nil {
 		log.Error(err)
-		db.Jobs.UpdateJobStatus(job.GUID, types.JobError)
+		db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobError)
 		return
 	}
 
@@ -217,7 +217,7 @@ func runEncodeJob(job types.Job) {
 	err = cleanup(job)
 	if err != nil {
 		log.Error(err)
-		db.Jobs.UpdateJobStatus(job.GUID, types.JobError)
+		db.Jobs.UpdateJobStatusByGUID(job.GUID, types.JobError)
 		return
 	}
 

--- a/web/src/components/JobsTable.vue
+++ b/web/src/components/JobsTable.vue
@@ -13,23 +13,30 @@
 
       <template v-slot:cell(status)="data">
         <b-badge
-          :variant="data.item.status === 'error' ? 'danger' : 'primary'"
+          :variant="['error', 'cancelled'].includes(data.item.status) ? 'danger' : 'primary'"
         >{{ data.item.status }}</b-badge>
       </template>
 
       <template v-slot:cell(progress)="data">
         <b-progress
-          v-if="data.item.status !== 'error'"
+          v-if="!['error', 'cancelled'].includes(data.item.status)"
           :value="data.item.progress"
           :animated="data.value !== 100"
           :variant="data.value === 100 ? 'success' : 'primary'"
           show-progress></b-progress>
       </template>
 
-      <template v-slot:cell(show_details)="row">
+      <template v-slot:cell(details)="row">
         <b-button size="sm" @click="row.toggleDetails" class="mr-2">
-          {{ row.detailsShowing ? 'Hide' : 'Show'}} Details
+          {{ row.detailsShowing ? 'Hide' : 'Show'}}
         </b-button>
+      </template>
+
+      <template v-slot:cell(action)="data">
+        <b-button-group size="sm">
+        <b-button variant="light" @click="onClickCancel(data.item.id)">❌</b-button>
+        <b-button variant="light" @click="onClickRestart(data.item.id)">&#10227;</b-button>
+        </b-button-group>
       </template>
 
       <template v-slot:row-details="row">
@@ -82,7 +89,7 @@ let intervalId;
 export default {
   data() {
     return {
-      fields: ['id', 'source', 'preset', 'created_date', 'status', 'progress', 'show_details'],
+      fields: ['id', 'source', 'preset', 'created_date', 'status', 'progress', 'details', 'action'],
       items: [],
       count: 0,
       autoUpdate: true,
@@ -121,6 +128,42 @@ export default {
 
     onChangePage(event) {
       this.getJobs(event);
+    },
+
+    onClickCancel(evt) {
+      const id = evt;
+      this.cancelJob(id);
+    },
+
+    onClickRestart(evt) {
+      const id = evt;
+      this.restartJob(id);
+    },
+
+    cancelJob(id) {
+      const url = `/api/jobs/${id}/cancel`;
+
+      this.$http.post(url, {
+        method: 'POST',
+        headers: auth.getAuthHeader(),
+      }).then(response => (
+        response.json()
+      )).then((json) => {
+        console.log('Cancel job: ', json);
+      });
+    },
+
+    restartJob(id) {
+      const url = `/api/jobs/${id}/restart`;
+
+      this.$http.post(url, {
+        method: 'POST',
+        headers: auth.getAuthHeader(),
+      }).then(response => (
+        response.json()
+      )).then((json) => {
+        console.log('Restart job: ', json);
+      });
     },
 
     getJobs(page) {

--- a/web/src/components/JobsTable.vue
+++ b/web/src/components/JobsTable.vue
@@ -9,6 +9,7 @@
     <b-table
       striped hover dark
       :fields="fields"
+      :busy="!items"
       :items="items">
 
       <template v-slot:cell(status)="data">
@@ -34,8 +35,14 @@
 
       <template v-slot:cell(action)="data">
         <b-button-group size="sm">
-        <b-button variant="light" @click="onClickCancel(data.item.id)">❌</b-button>
-        <b-button variant="light" @click="onClickRestart(data.item.id)">&#10227;</b-button>
+          <b-button
+            variant="light"
+            v-if="!['error', 'cancelled', 'completed'].includes(data.item.status)"
+            @click="onClickCancel(data.item.id)">❌</b-button>
+          <b-button
+            variant="light"
+            v-if="['error', 'cancelled'].includes(data.item.status)"
+            @click="onClickRestart(data.item.id)">&#10227;</b-button>
         </b-button-group>
       </template>
 
@@ -69,6 +76,13 @@
           </b-row>
       </template>
 
+      <template v-slot:table-busy>
+        <div class="text-center text-danger my-2">
+          <b-spinner class="align-middle"></b-spinner>
+          <strong>Loading...</strong>
+        </div>
+      </template>
+
     </b-table>
     <h2 class="text-center" v-if="items.length === 0">No Jobs Found</h2>
 
@@ -90,7 +104,7 @@ export default {
   data() {
     return {
       fields: ['id', 'source', 'preset', 'created_date', 'status', 'progress', 'details', 'action'],
-      items: [],
+      items: null,
       count: 0,
       autoUpdate: true,
     };


### PR DESCRIPTION
* Worker: Add option to cancel running ffmpeg job.
* API: New endpoints for cancelling, restarting and checking job status and re-submitting to queue.
* DB: New database methods for getting job statuses.
* Web: New "Action" buttons for cancelling and restarting jobs.